### PR TITLE
Add agendas and decision lists to the export

### DIFF
--- a/config/delta-producer/besluiten/export.json
+++ b/config/delta-producer/besluiten/export.json
@@ -196,6 +196,8 @@
         "http://www.w3.org/ns/prov#endedAtTime",
         "http://data.vlaanderen.be/ns/besluit#heeftAanwezigeBijStart",
         "http://data.vlaanderen.be/ns/besluit#heeftNotulen",
+        "http://data.vlaanderen.be/ns/besluit#heeftAgenda",
+        "http://data.vlaanderen.be/ns/besluit#heeftBesluitenlijst",
         "http://data.vlaanderen.be/ns/besluit#heeftSecretaris",
         "http://data.vlaanderen.be/ns/besluit#heeftVoorzitter",
         "http://data.vlaanderen.be/ns/besluit#heeftZittingsverslag",


### PR DESCRIPTION
I wasn't sure to whom ask the review, so ... many requests sorry :grimacing: 

This is about OP-1880 , we noticed that the triples linking a meeting to agendas and decision lists were not exported to CVP. This PR just adds the relevant configuration.

Once deploy, we'll just have to wait until the next healing (2am everyday) for the triples to be added to the publication graph and exported in delta files.