### PR TITLE
Add error-alert service to receive emails when things go wrong

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -352,4 +352,25 @@ export default [
       optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
     },
   },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+      },
+      object: {
+        type: 'uri',
+        value:'http://open-services.net/ns/core#Error'
+      }
+    },
+    callback: {
+      url: 'http://error-alert/delta',
+      method:'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true
+    }
+  },
 ];

--- a/config/error-alert/config.json
+++ b/config/error-alert/config.json
@@ -1,0 +1,7 @@
+{
+  "creators": [
+    "http://lblod.data.gift/services/delta-producer-background-jobs-initiator-besluiten",
+    "http://lblod.data.gift/services/delta-producer-publication-graph-maintainer-besluiten",
+    "http://lblod.data.gift/services/delta-producer-dump-file-publisher"
+  ]
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,8 @@ services:
     restart: "no"
   frontend:
     restart: "no"
+  migrations:
+    restart: "no"
   virtuoso:
     restart: "no"
     ports:
@@ -40,8 +42,10 @@ services:
   deliver-email-service:
     restart: "no"
   delta-producer-report-generator:
-     restart: "no"
+    restart: "no"
   delta-producer-background-jobs-initiator-besluiten:
-     restart: "no"
+    restart: "no"
   delta-producer-publication-graph-maintainer-besluiten:
-     restart: "no"
+    restart: "no"
+  error-alert:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-dump-file-publisher:
-    image: lblod/delta-producer-dump-file-publisher:0.3.2
+    image: lblod/delta-producer-dump-file-publisher:0.9.0
     environment:
       FILES_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       DCAT_DATASET_GRAPH: "http://mu.semte.ch/graphs/harvesting"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,14 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  error-alert:
+    image: lblod/loket-error-alert-service:1.0.0
+    volumes:
+      - ./config/error-alert:/config/
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   ################################################################################
   # DELTA GENERAL
   ################################################################################
@@ -232,6 +240,7 @@ services:
       CRON_PATTERN_DUMP_JOB: "0 0 0 * * 6" # weekly on saturday
       CRON_PATTERN_HEALING_JOB: "0 0 2 * * *" # everyday at 2 AM
       START_INITIAL_SYNC: "false" # prefer to disable it now. We want to have feeling with how the DB acts.
+      ERROR_CREATOR_URI: 'http://lblod.data.gift/services/delta-producer-background-jobs-initiator-besluiten'
     labels:
       - "logging=true"
     restart: always
@@ -255,6 +264,7 @@ services:
       PRETTY_PRINT_DIFF_JSON: "true"
       FILES_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       ERROR_GRAPH: "http://mu.semte.ch/graphs/harvesting"
+      ERROR_CREATOR_URI: 'http://lblod.data.gift/services/delta-producer-publication-graph-maintainer-besluiten'
     volumes:
       - ./config/delta-producer/besluiten:/config
       - ./data/files/:/share

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -231,7 +231,7 @@ services:
   # DELTA BESLUITEN
   ################################################################################
   delta-producer-background-jobs-initiator-besluiten:
-    image: lblod/delta-producer-background-jobs-initiator:0.4.0
+    image: lblod/delta-producer-background-jobs-initiator:0.4.1
     environment:
       JOBS_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       DUMP_FILE_CREATION_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/besluiten"
@@ -246,7 +246,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-publication-graph-maintainer-besluiten:
-    image: lblod/delta-producer-publication-graph-maintainer:0.15.1
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.2
     environment:
       SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404"
       MAX_BODY_SIZE: "50mb"


### PR DESCRIPTION
To better monitor problems occurring in the harvesting flow, I added the error-alert service to the stack.

This PR goes together with the following ones to get more details on the errors:
- https://github.com/lblod/delta-producer-dump-file-publisher/pull/5
- https://github.com/lblod/delta-producer-publication-graph-maintainer/pull/8
- https://github.com/lblod/delta-producer-background-jobs-initiator/pull/2