### PR TITLE
Add Job pipelines for Worship Services

### DIFF
--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -91,6 +91,79 @@
       }
     ]
   },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestWorship": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
+        "nextIndex": "2"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
+        "nextIndex": "3"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "4"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
+        "nextIndex": "5"
+      }
+    ]
+  },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestWorshipAndPublish": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
+        "nextIndex": "2"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
+        "nextIndex": "3"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "4"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriples",
+        "nextIndex": "5"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriples",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
+        "nextIndex": "6"
+      }
+    ]
+  },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/besluiten": {
     "tasksConfiguration": [
       {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     restart: always
     logging: *default-logging
   frontend:
-    image: lblod/frontend-harvesting-self-service:1.6.0
+    image: lblod/frontend-harvesting-self-service:1.7.0
     volumes:
       - ./config/frontend:/config
     labels:


### PR DESCRIPTION
This adds copies of existing pipelines but for harvesting Worship Services. These do not include a filtering step.
These changes go along with https://github.com/lblod/frontend-harvesting-self-service/pull/17.