### PR TITLE
Adding UUIDs in harvest worship pipeline

### DIFF
--- a/config/delta-producer/worship/export.json
+++ b/config/delta-producer/worship/export.json
@@ -4,6 +4,7 @@
       "type": "http://data.lblod.info/vocabularies/erediensten/EredienstMandataris",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://data.lblod.info/vocabularies/erediensten/geplandeEinddatumAanstelling",
         "http://data.lblod.info/vocabularies/erediensten/redenVanStopzetting",
         "http://data.vlaanderen.be/ns/mandaat#rangorde",
@@ -32,6 +33,7 @@
       "type": "http://data.lblod.info/vocabularies/erediensten/RolBedienaar",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/ns/org#holds",
         "http://data.lblod.info/vocabularies/erediensten/financiering",
         "http://www.w3.org/ns/org#siteAddress",
@@ -46,6 +48,7 @@
       "type": "http://www.w3.org/ns/person#Person",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://xmlns.com/foaf/0.1/familyName",
         "http://xmlns.com/foaf/0.1/name",
         "http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
@@ -62,6 +65,7 @@
       "type": "http://www.w3.org/ns/adms#Identifier",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator",
         "http://www.w3.org/2004/02/skos/core#notation",
         "http://purl.org/dc/terms/creator",
@@ -73,6 +77,7 @@
       "type": "https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "https://data.vlaanderen.be/ns/generiek#lokaleIdentificator",
         "https://data.vlaanderen.be/ns/generiek#naamruimte",
         "https://data.vlaanderen.be/ns/generiek#versieIdentificator"
@@ -82,6 +87,7 @@
       "type": "https://data.vlaanderen.be/ns/persoon#Geboorte",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "https://data.vlaanderen.be/ns/persoon#datum"
       ]
     },
@@ -89,6 +95,7 @@
       "type": "http://schema.org/ContactPoint",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2006/vcard/ns#honorific-prefix",
         "http://www.w3.org/ns/locn#address",
         "http://schema.org/hoursAvailable",
@@ -109,6 +116,7 @@
       "type": "http://www.w3.org/ns/locn#Address",
       "graphsFilter": [ "http://mu.semte.ch/graphs/public" ],
       "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/ns/locn#location",
         "http://www.w3.org/ns/locn#geographicName",
         "http://www.w3.org/ns/locn#seeAlso",

--- a/config/delta-producer/worship/export.json
+++ b/config/delta-producer/worship/export.json
@@ -51,7 +51,7 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://xmlns.com/foaf/0.1/familyName",
         "http://xmlns.com/foaf/0.1/name",
-        "http://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
+        "https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
         "https://data.vlaanderen.be/ns/persoon#geslacht",
         "http://www.w3.org/ns/person#geslacht",
         "https://data.vlaanderen.be/ns/persoon#heeftGeboorte",

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -115,8 +115,13 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
         "nextIndex": "4"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
@@ -154,8 +159,13 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
         "nextIndex": "4"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
     restart: always
     logging: *default-logging
   harvesting-diff:
-    image: lblod/harvesting-diff-service:0.1.0
+    image: lblod/harvesting-diff-service:0.1.1
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:


### PR DESCRIPTION
Adds UUIDs to individuals in data that is being imported if they don't exist yet. In any case, a UUID is provided for any individual that has a `rdf:type`.

Relies on a version of the [import-with-sameas-service](https://github.com/lblod/import-with-sameas-service) with PR https://github.com/lblod/import-with-sameas-service/pull/9.