### PR TITLE
Singleton Jobs

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -22,6 +22,28 @@ export default [
       },
       object: {
         type: 'uri',
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
+    },
+    callback: {
+      method: 'POST',
+      url: 'http://harvesting-singleton-jobs/delta',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status',
+      },
+      object: {
+        type: 'uri',
         value: 'http://lblod.data.gift/file-download-statuses/ready-to-be-cached',
       },
     },

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -95,43 +95,48 @@
     "tasksConfiguration": [
       {
         "currentOperation": null,
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
         "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
+        "nextIndex": "1"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
-        "nextIndex": "1"
+        "nextIndex": "2"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
-        "nextIndex": "2"
+        "nextIndex": "3"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
-        "nextIndex": "3"
+        "nextIndex": "4"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
-        "nextIndex": "4"
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
-        "nextIndex": "5"
+        "nextIndex": "6"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
-        "nextIndex": "6"
+        "nextIndex": "7"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/execute-diff-deletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "7"
+        "nextIndex": "8"
       }
     ]
   },
@@ -139,43 +144,48 @@
     "tasksConfiguration": [
       {
         "currentOperation": null,
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
         "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
+        "nextIndex": "1"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
-        "nextIndex": "1"
+        "nextIndex": "2"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
-        "nextIndex": "2"
+        "nextIndex": "3"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
-        "nextIndex": "3"
+        "nextIndex": "4"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
-        "nextIndex": "4"
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/add-uuids",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
-        "nextIndex": "5"
+        "nextIndex": "6"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
-        "nextIndex": "6"
+        "nextIndex": "7"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriplesWithDeletes",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "7"
+        "nextIndex": "8"
       }
     ]
   },

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -3,38 +3,43 @@
     "tasksConfiguration": [
       {
         "currentOperation": null,
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
         "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
+        "nextIndex": "1"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
-        "nextIndex": "1"
+        "nextIndex": "2"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
-        "nextIndex": "2"
+        "nextIndex": "3"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/filtering",
-        "nextIndex": "3"
+        "nextIndex": "4"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/filtering",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
-        "nextIndex": "4"
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
-        "nextIndex": "5"
+        "nextIndex": "6"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "6"
+        "nextIndex": "7"
       }
     ]
   },
@@ -51,43 +56,48 @@
     "tasksConfiguration": [
       {
         "currentOperation": null,
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
         "nextIndex": "0"
       },
       {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
         "nextIndex": "1"
       },
       {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
+        "nextIndex": "2"
+      },
+      {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/importing",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
-        "nextIndex": "2"
+        "nextIndex": "3"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/validating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/filtering",
-        "nextIndex": "3"
+        "nextIndex": "4"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/filtering",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
-        "nextIndex": "4"
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/mirroring",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
-        "nextIndex": "5"
+        "nextIndex": "6"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/diff",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriples",
-        "nextIndex": "6"
+        "nextIndex": "7"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/publishHarvestedTriples",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
-        "nextIndex": "7"
+        "nextIndex": "8"
       }
     ]
   },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,8 @@ services:
     restart: "no"
   file:
     restart: "no"
+  harvesting-singleton-jobs:
+    restart: "no"
   harvesting-download-url:
     environment:
       CACHING_MAX_RETRIES: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,12 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  harvesting-singleton-jobs:
+    image: lblod/harvesting-singleton-job-service:1.0.0
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   harvesting-download-url:
     image: lblod/download-url-service:1.0.1
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     restart: always
     logging: *default-logging
   frontend:
-    image: lblod/frontend-harvesting-self-service:2.0.1
+    image: lblod/frontend-harvesting-self-service:2.1.0-beta.1
     volumes:
       - ./config/frontend:/config
     labels:
@@ -101,7 +101,7 @@ services:
     restart: always
     logging: *default-logging
   harvesting-singleton-jobs:
-    image: lblod/harvesting-singleton-job-service:1.0.0
+    image: lblod/harvesting-singleton-job-service:1.0.0-beta.2
     labels:
       - "logging=true"
     restart: always
@@ -128,7 +128,7 @@ services:
     restart: always
     logging: *default-logging
   harvest-collector:
-    image: lblod/harvest-collector-service:0.8.0
+    image: lblod/harvest-collector-service:0.9.0-beta.1
     volumes:
       - ./data/files:/share
     labels:


### PR DESCRIPTION
DL-5036, DL-5086

All changes needed for supporting singleton-jobs.

A job for a specific subject can only run once at a time. In the case of the harvester, there should only be one harvesting job running at a time for the same URL. This is done by introducing a new service in the pipeline that finds another running job for the same subject and fails the job if so. If not found, the task is successful and the rest of the tasks can be run.

**How to test**

The changes are based on beta builds of the affected services. Test them out and make sure that all harvesting Jobs still work as expected. Make sure that all harvesting Jobs start with a "singleton-job" task.