### PR TITLE
Renames of services and version upgrades

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -27,7 +27,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvesting-singleton-jobs/delta',
+      url: 'http://harvest_singleton-job/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -49,7 +49,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvesting-download-url/process-remote-data-objects',
+      url: 'http://harvest_download-url/process-remote-data-objects',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -71,7 +71,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest-collector/delta',
+      url: 'http://harvest_collector/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -93,7 +93,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest-collector/delta',
+      url: 'http://harvest_collector/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -115,7 +115,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest-collector/on-download-failure',
+      url: 'http://harvest_collector/on-download-failure',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -137,7 +137,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvesting-import/delta',
+      url: 'http://harvest_import/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -159,7 +159,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvesting-validator/delta',
+      url: 'http://harvest_validator/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -181,7 +181,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvesting-diff/delta',
+      url: 'http://harvest_diff/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -203,7 +203,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest-check-url/delta',
+      url: 'http://harvest_check-url/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -225,7 +225,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://harvesting-sameas/delta',
+      url: 'http://harvest_sameas/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -243,7 +243,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://job-controller-service/delta',
+      url: 'http://job-controller/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -407,7 +407,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://scheduled-job-controller-service/delta',
+      url: 'http://scheduled-job-controller/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -429,7 +429,7 @@ export default [
     },
     callback: {
       method: 'POST',
-      url: 'http://scheduled-job-controller-service/delta',
+      url: 'http://scheduled-job-controller/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,64 +1,92 @@
 version: '3.7'
 
 services:
+
   identifier:
     restart: "no"
+
   dispatcher:
     restart: "no"
+
   frontend:
     restart: "no"
+
   database:
     restart: "no"
+
   virtuoso:
     restart: "no"
+
   migrations:
     restart: "no"
+
   cache:
     restart: "no"
+
   resource:
     restart: "no"
+
   deltanotifier:
     restart: "no"
+
   file:
     restart: "no"
+
   harvest_singleton-job:
     restart: "no"
+
   harvest_download-url:
     environment:
       CACHING_MAX_RETRIES: 5
     restart: "no"
+
   harvest_check-url:
     restart: "no"
+
   harvest_collector:
     restart: "no"
+
   harvest_import:
     restart: "no"
+
   harvest_validator:
     restart: "no"
+
   harvest_diff:
     restart: "no"
+
   harvest_sameas:
     restart: "no"
+
   job-controller:
     restart: "no"
+
   scheduled-job-controller:
     restart: "no"
+
   deliver-email:
     restart: "no"
+
   error-alert:
     environment:
       EMAIL_FROM: "noreply@lblod.info"
       EMAIL_TO: "noreply@lblod.info"
     restart: "no"
+
   delta-producer-report-generator:
     restart: "no"
+
   delta-producer-dump-file-publisher:
     restart: "no"
+
   delta-producer-background-jobs-initiator-besluiten:
     restart: "no"
+
   delta-producer-publication-graph-maintainer-besluiten:
     restart: "no"
+
   delta-producer-background-jobs-initiator-worship:
     restart: "no"
+
   delta-producer-publication-graph-maintainer-worship:
     restart: "no"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,19 +3,15 @@ version: '3.7'
 services:
   identifier:
     restart: "no"
-    ports:
-      - "80:80"
   dispatcher:
     restart: "no"
   frontend:
     restart: "no"
-  migrations:
+  database:
     restart: "no"
   virtuoso:
     restart: "no"
-    ports:
-      - "8890:8890"
-  database:
+  migrations:
     restart: "no"
   cache:
     restart: "no"
@@ -25,38 +21,44 @@ services:
     restart: "no"
   file:
     restart: "no"
-  harvesting-singleton-jobs:
+  harvest_singleton-job:
     restart: "no"
-  harvesting-download-url:
+  harvest_download-url:
     environment:
       CACHING_MAX_RETRIES: 5
     restart: "no"
-  harvest-collector:
+  harvest_check-url:
     restart: "no"
-  harvesting-import:
+  harvest_collector:
     restart: "no"
-  harvesting-sameas:
+  harvest_import:
     restart: "no"
-  job-controller-service:
+  harvest_validator:
     restart: "no"
-  scheduled-job-controller-service:
+  harvest_diff:
     restart: "no"
-  deliver-email-service:
+  harvest_sameas:
     restart: "no"
-  delta-producer-report-generator:
+  job-controller:
     restart: "no"
-  delta-producer-background-jobs-initiator-besluiten:
+  scheduled-job-controller:
     restart: "no"
-  delta-producer-publication-graph-maintainer-besluiten:
-    restart: "no"
-  delta-producer-publication-graph-maintainer-worship:
-    restart: "no"
-  harvesting-validator:
-    restart: "no"
-  harvesting-diff:
+  deliver-email:
     restart: "no"
   error-alert:
     environment:
       EMAIL_FROM: "noreply@lblod.info"
       EMAIL_TO: "noreply@lblod.info"
+    restart: "no"
+  delta-producer-report-generator:
+    restart: "no"
+  delta-producer-dump-file-publisher:
+    restart: "no"
+  delta-producer-background-jobs-initiator-besluiten:
+    restart: "no"
+  delta-producer-publication-graph-maintainer-besluiten:
+    restart: "no"
+  delta-producer-background-jobs-initiator-worship:
+    restart: "no"
+  delta-producer-publication-graph-maintainer-worship:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ x-logging: &default-logging
     max-file: "3"
 
 services:
+
   identifier:
     image: semtech/mu-identifier:1.10.0
     environment:
@@ -16,6 +17,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   dispatcher:
     image: semtech/mu-dispatcher:2.1.0-beta.2
     volumes:
@@ -24,6 +26,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   frontend:
     image: lblod/frontend-harvesting-self-service:2.1.0-beta.1
     volumes:
@@ -32,6 +35,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   database:
     image: semtech/mu-authorization:0.6.0-beta.8
     environment:
@@ -42,6 +46,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   virtuoso:
     image: redpencil/virtuoso:1.1.0
     environment:
@@ -55,6 +60,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   migrations:
     image: semtech/mu-migrations-service:0.8.0
     links:
@@ -64,6 +70,7 @@ services:
     restart: always
     labels:
       - "logging=true"
+
   cache:
     image: semtech/mu-cache:2.0.2
     links:
@@ -72,6 +79,7 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
+
   resource:
     image: semtech/mu-cl-resources:1.22.0
     environment:
@@ -82,6 +90,7 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
+
   deltanotifier:
     image: cecemel/delta-notifier:0.2.0-beta.3
     volumes:
@@ -90,6 +99,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   file:
     image: semtech/mu-file-service:3.3.0
     environment:
@@ -100,12 +110,14 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_singleton-job:
     image: lblod/harvesting-singleton-job-service:1.0.0-beta.2
     labels:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_download-url:
     image: lblod/download-url-service:1.0.3
     volumes:
@@ -119,6 +131,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_check-url:
     image: lblod/harvest-check-url-collection-service:1.2.1
     volumes:
@@ -127,6 +140,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_collector:
     image: lblod/harvest-collector-service:0.9.0-beta.1
     volumes:
@@ -135,6 +149,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_import:
     image: lblod/harvesting-import-service:0.7.1
     environment:
@@ -145,6 +160,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_validator:
     image: lblod/harvesting-validator:0.1.7
     environment:
@@ -157,6 +173,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_diff:
     image: lblod/harvesting-diff-service:0.1.3
     environment:
@@ -167,6 +184,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   harvest_sameas:
     image: lblod/import-with-sameas-service:3.1.0
     environment:
@@ -179,6 +197,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   job-controller:
     image: lblod/job-controller-service:1.0.0
     volumes:
@@ -187,6 +206,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   scheduled-job-controller:
     image: lblod/scheduled-job-controller-service:0.1.0-beta.5
     environment:
@@ -200,6 +220,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   deliver-email:
     image: redpencil/deliver-email-service:0.3.3
     environment:
@@ -208,6 +229,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   error-alert:
     image: lblod/loket-error-alert-service:1.0.0
     volumes:
@@ -216,9 +238,11 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  ################################################################################
+
+  #############################################################################
   # DELTA GENERAL
-  ################################################################################
+  #############################################################################
+
   delta-producer-report-generator:
     image: lblod/delta-producer-report-generator:0.4.0
     volumes:
@@ -229,6 +253,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   delta-producer-dump-file-publisher:
     image: lblod/delta-producer-dump-file-publisher:0.9.1
     environment:
@@ -242,9 +267,11 @@ services:
     #      - "logging=true"
     restart: always
     logging: *default-logging
-  ################################################################################
+
+  #############################################################################
   # DELTA BESLUITEN
-  ################################################################################
+  #############################################################################
+
   delta-producer-background-jobs-initiator-besluiten:
     image: lblod/delta-producer-background-jobs-initiator:0.4.2
     environment:
@@ -260,6 +287,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   delta-producer-publication-graph-maintainer-besluiten:
     image: lblod/delta-producer-publication-graph-maintainer:0.15.4
     environment:
@@ -288,12 +316,15 @@ services:
     #      - "logging=true"
     restart: always
     logging: *default-logging
-  ################################################################################
+
+  #############################################################################
   # DELTA BESLUITEN: END
-  ################################################################################
-  ################################################################################
+  #############################################################################
+
+  #############################################################################
   # DELTA WORSHIP: START
-  ################################################################################
+  #############################################################################
+
   delta-producer-background-jobs-initiator-worship:
     image: lblod/delta-producer-background-jobs-initiator:0.4.2
     environment:
@@ -309,6 +340,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
   delta-producer-publication-graph-maintainer-worship:
     image: lblod/delta-producer-publication-graph-maintainer:0.15.4
     environment:
@@ -336,6 +368,7 @@ services:
       - ./data/files/:/share
     restart: always
     logging: *default-logging
-################################################################################
+
+###############################################################################
 # DELTA WORSHIP: END
-################################################################################
+###############################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     logging: *default-logging
 
   frontend:
-    image: lblod/frontend-harvesting-self-service:2.1.0-beta.1
+    image: lblod/frontend-harvesting-self-service:2.1.0
     volumes:
       - ./config/frontend:/config
     labels:
@@ -112,7 +112,7 @@ services:
     logging: *default-logging
 
   harvest_singleton-job:
-    image: lblod/harvesting-singleton-job-service:1.0.0-beta.2
+    image: lblod/harvesting-singleton-job-service:1.0.0
     labels:
       - "logging=true"
     restart: always
@@ -142,7 +142,7 @@ services:
     logging: *default-logging
 
   harvest_collector:
-    image: lblod/harvest-collector-service:0.9.0-beta.1
+    image: lblod/harvest-collector-service:0.9.0
     volumes:
       - ./data/files:/share
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   identifier:
-    image: semtech/mu-identifier:1.9.1
+    image: semtech/mu-identifier:1.10.0
     environment:
       DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: '[{"variables":[],"name":"harvesting"}, {"variables":[],"name":"clean"}]'
       DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER: "*"
@@ -33,7 +33,7 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: cecemel/mu-authorization:0.6.0-beta.8
+    image: semtech/mu-authorization:0.6.0-beta.8
     environment:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
     volumes:
@@ -43,7 +43,7 @@ services:
     restart: always
     logging: *default-logging
   virtuoso:
-    image: tenforce/virtuoso:1.3.2-virtuoso7.2.2
+    image: redpencil/virtuoso:1.1.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/public"
@@ -56,7 +56,7 @@ services:
     restart: always
     logging: *default-logging
   migrations:
-    image: semtech/mu-migrations-service:0.7.0
+    image: semtech/mu-migrations-service:0.8.0
     links:
       - virtuoso:database
     volumes:
@@ -73,7 +73,7 @@ services:
       - "logging=true"
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:1.21.1
+    image: semtech/mu-cl-resources:1.22.0
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     volumes:
@@ -83,7 +83,7 @@ services:
       - "logging=true"
     logging: *default-logging
   deltanotifier:
-    image: cecemel/delta-notifier:0.2.0-beta.2
+    image: cecemel/delta-notifier:0.2.0-beta.3
     volumes:
       - ./config/delta:/config
     labels:
@@ -91,7 +91,7 @@ services:
     restart: always
     logging: *default-logging
   file:
-    image: semtech/mu-file-service:3.1.0
+    image: semtech/mu-file-service:3.3.0
     environment:
       MU_APPLICATION_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:
@@ -107,7 +107,7 @@ services:
     restart: always
     logging: *default-logging
   harvesting-download-url:
-    image: lblod/download-url-service:1.0.1
+    image: lblod/download-url-service:1.0.3
     volumes:
       - ./data/files:/share
     environment:
@@ -180,7 +180,7 @@ services:
     restart: always
     logging: *default-logging
   job-controller-service:
-    image: lblod/job-controller-service:0.7.2
+    image: lblod/job-controller-service:1.0.0
     volumes:
       - ./config/job-controller:/config
     labels:
@@ -201,7 +201,7 @@ services:
     restart: always
     logging: *default-logging
   deliver-email-service:
-    image: redpencil/deliver-email-service:0.3.1
+    image: redpencil/deliver-email-service:0.3.3
     environment:
       MAILBOX_URI: "http://data.lblod.info/id/mailboxes/1"
     labels:
@@ -230,7 +230,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-dump-file-publisher:
-    image: lblod/delta-producer-dump-file-publisher:0.9.0
+    image: lblod/delta-producer-dump-file-publisher:0.9.1
     environment:
       FILES_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       DCAT_DATASET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
@@ -246,7 +246,7 @@ services:
   # DELTA BESLUITEN
   ################################################################################
   delta-producer-background-jobs-initiator-besluiten:
-    image: lblod/delta-producer-background-jobs-initiator:0.4.1
+    image: lblod/delta-producer-background-jobs-initiator:0.4.2
     environment:
       JOBS_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       DUMP_FILE_CREATION_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/besluiten"
@@ -261,7 +261,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-publication-graph-maintainer-besluiten:
-    image: lblod/delta-producer-publication-graph-maintainer:0.15.2
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.4
     environment:
       SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404"
       MAX_BODY_SIZE: "50mb"
@@ -295,7 +295,7 @@ services:
   # DELTA WORSHIP: START
   ################################################################################
   delta-producer-background-jobs-initiator-worship:
-    image: lblod/delta-producer-background-jobs-initiator:0.4.1
+    image: lblod/delta-producer-background-jobs-initiator:0.4.2
     environment:
       JOBS_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       DUMP_FILE_CREATION_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/worship"
@@ -310,7 +310,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-publication-graph-maintainer-worship:
-    image: lblod/delta-producer-publication-graph-maintainer:0.15.2
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.4
     environment:
       SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404"
       MAX_BODY_SIZE: "50mb"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,13 +100,13 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvesting-singleton-jobs:
+  harvest_singleton-job:
     image: lblod/harvesting-singleton-job-service:1.0.0-beta.2
     labels:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvesting-download-url:
+  harvest_download-url:
     image: lblod/download-url-service:1.0.3
     volumes:
       - ./data/files:/share
@@ -119,7 +119,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvest-check-url:
+  harvest_check-url:
     image: lblod/harvest-check-url-collection-service:1.2.1
     volumes:
       - ./data/files:/share
@@ -127,7 +127,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvest-collector:
+  harvest_collector:
     image: lblod/harvest-collector-service:0.9.0-beta.1
     volumes:
       - ./data/files:/share
@@ -135,7 +135,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvesting-import:
+  harvest_import:
     image: lblod/harvesting-import-service:0.7.1
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
@@ -145,7 +145,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvesting-validator:
+  harvest_validator:
     image: lblod/harvesting-validator:0.1.7
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
@@ -157,7 +157,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvesting-diff:
+  harvest_diff:
     image: lblod/harvesting-diff-service:0.1.3
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
@@ -167,7 +167,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  harvesting-sameas:
+  harvest_sameas:
     image: lblod/import-with-sameas-service:3.1.0
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
@@ -179,7 +179,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  job-controller-service:
+  job-controller:
     image: lblod/job-controller-service:1.0.0
     volumes:
       - ./config/job-controller:/config
@@ -187,7 +187,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  scheduled-job-controller-service:
+  scheduled-job-controller:
     image: lblod/scheduled-job-controller-service:0.1.0-beta.5
     environment:
       # NOTE: if the delta-events prove to inaccurate,
@@ -200,7 +200,7 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-  deliver-email-service:
+  deliver-email:
     image: redpencil/deliver-email-service:0.3.3
     environment:
       MAILBOX_URI: "http://data.lblod.info/id/mailboxes/1"


### PR DESCRIPTION
Some services could use a more consistent name. General rules:

- The names should be as short as possible, but still clear
- No 'service' in the name
- Harvesting related services prefixed with 'harvest_' (this was inconsistent with a mix of 'harvesting-' and 'harvest-')

A lot of core services are now more up to date. E.g. we now use the RedPencil version of Virtuoso, the new mu-cl-resources, ...