### PR TITLE
use lblod-scraper instead of download-url and collect service

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -44,78 +44,12 @@ export default [
       },
       object: {
         type: 'uri',
-        value: 'http://lblod.data.gift/file-download-statuses/ready-to-be-cached',
-      },
-    },
-    callback: {
-      method: 'POST',
-      url: 'http://harvest_download-url/process-remote-data-objects',
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
-    },
-  },
-  {
-    match: {
-      predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status',
-      },
-      object: {
-        type: 'uri',
         value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
       },
     },
     callback: {
       method: 'POST',
-      url: 'http://harvest_collect/delta',
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
-    },
-  },
-  {
-    match: {
-      predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status',
-      },
-      object: {
-        type: 'uri',
-        value: 'http://lblod.data.gift/file-download-statuses/success',
-      },
-    },
-    callback: {
-      method: 'POST',
-      url: 'http://harvest_collect/delta',
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
-    },
-  },
-  {
-    match: {
-      predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status',
-      },
-      object: {
-        type: 'uri',
-        value: 'http://lblod.data.gift/file-download-statuses/failure',
-      },
-    },
-    callback: {
-      method: 'POST',
-      url: 'http://harvest_collect/on-download-failure',
+      url: 'http://harvest_scraper/delta',
     },
     options: {
       resourceFormat: 'v0.0.1',
@@ -260,6 +194,33 @@ export default [
       },
       object: {
         type: 'uri',
+        value: 'http://vocab.deri.ie/cogs#ScheduledJob',
+      },
+    },
+    callback: {
+      method: 'POST',
+      url: 'http://scheduled-job-controller/delta',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      //Allow more time (10s) for the frontend to have saved everything. If the
+      //scheduled-job exists before its tasks and authentication configuration,
+      //then the scheduled job service tries to query that data before it is
+      //written to the triplestore, failing to encrypt the secrets for the
+      //scheduled task.
+      gracePeriod: 10000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+      },
+      object: {
+        type: 'uri',
         value: 'http://redpencil.data.gift/vocabularies/deltas/Error',
       },
     },
@@ -370,33 +331,6 @@ export default [
     options: {
       resourceFormat: 'v0.0.1',
       gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
-    },
-  },
-  {
-    match: {
-      predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
-      },
-      object: {
-        type: 'uri',
-        value: 'http://vocab.deri.ie/cogs#ScheduledJob',
-      },
-    },
-    callback: {
-      method: 'POST',
-      url: 'http://scheduled-job-controller/delta',
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      //Allow more time (10s) for the frontend to have saved everything. If the
-      //scheduled-job exists before its tasks and authentication configuration,
-      //then the scheduled job service tries to query that data before it is
-      //written to the triplestore, failing to encrypt the secrets for the
-      //scheduled task.
-      gracePeriod: 10000,
       ignoreFromSelf: true,
       optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
     },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,15 +37,10 @@ services:
   harvest_singleton-job:
     restart: "no"
 
-  harvest_download-url:
-    environment:
-      CACHING_MAX_RETRIES: 5
-    restart: "no"
-
   harvest_check-url:
     restart: "no"
 
-  harvest_collect:
+  harvest_scraper:
     restart: "no"
 
   harvest_import:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,6 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-
   file:
     image: semtech/mu-file-service:3.3.0
     environment:
@@ -123,7 +122,7 @@ services:
     logging: *default-logging
 
   harvest_scraper:
-    image: nvdk/lblod-scraper
+    image: nvdk/lblod-scraper:1.0.0-beta.1
     volumes:
       - ./data/files:/share
     environment:
@@ -141,9 +140,8 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-
   harvest_import:
-    image: lblod/harvesting-import-service:0.7.1
+    image: lblod/harvesting-import-service:feature-gzip-support
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,15 +122,12 @@ services:
     restart: always
     logging: *default-logging
 
-  harvest_download-url:
-    image: lblod/download-url-service:1.0.3
+  harvest_scraper:
+    image: nvdk/lblod-scraper
     volumes:
       - ./data/files:/share
     environment:
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/harvesting"
-      CACHING_MAX_RETRIES: 10
-      CACHING_CRON_PATTERN: "0 */15 * * * *"
-      MAX_PENDING_TIME_IN_SECONDS: 7200
     labels:
       - "logging=true"
     restart: always
@@ -138,15 +135,6 @@ services:
 
   harvest_check-url:
     image: lblod/harvest-check-url-collection-service:1.2.1
-    volumes:
-      - ./data/files:/share
-    labels:
-      - "logging=true"
-    restart: always
-    logging: *default-logging
-
-  harvest_collect:
-    image: lblod/harvest-collector-service:0.9.0
     volumes:
       - ./data/files:/share
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     logging: *default-logging
 
   harvest_scraper:
-    image: nvdk/lblod-scraper:1.0.0-beta.1
+    image: nvdk/lblod-scraper:1.0.0-beta.2
     volumes:
       - ./data/files:/share
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     logging: *default-logging
 
   virtuoso:
-    image: redpencil/virtuoso:1.1.0
+    image: redpencil/virtuoso:1.0.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/public"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_import:
-    image: lblod/harvesting-import-service:feature-gzip-support
+    image: lblod/harvesting-import-service:0.8.0
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:


### PR DESCRIPTION
simplifies the flow by leveraging the scrapy framework. 

Seems to be working well, mainly tested with Gent and Laarne. Automated runs (not via frontend) of other cities also worked. 

Note: not 100% equal to previous services, lblod-scraper currently doesn't have a cron and doesn't create downloadEvent resources.