### PR TITLE
Convert `langString` to `string`

### DIFF
--- a/config/migrations/2023/2023-06-28T01:55:00.sparql
+++ b/config/migrations/2023/2023-06-28T01:55:00.sparql
@@ -1,0 +1,15 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o .
+  }
+}  INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?stringified .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o .
+    FILTER(datatype(?o) = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
+    BIND(STR(?o) AS ?stringified)
+  }
+}


### PR DESCRIPTION
Thanks to @aliokan for providing this query.

It converts all strings tagged as a `langString` to a regular `string`. `langString`s are not a conventional way to store strings, especially not when there is no language attached to it.