### PR TITLE
fix agressive filtering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
     logging: *default-logging
 
   harvest_validate:
-    image: lblod/harvesting-validator:0.1.8
+    image: lblod/harvesting-validator:0.2.0
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       STRICT_MODE_FILTERING: "false"


### PR DESCRIPTION
change the [logic](https://github.com/lblod/mu-java/blob/master/src/main/java/mu/semte/ch/lib/shacl/ShaclService.java#L103) of the filtering in order to allow subject where at least one rdf type is defined in the shacl profile.

- Made a unit test [here](https://github.com/lblod/mu-java/blob/master/src/test/java/mu/semte/ch/lib/shacl/ShaclServiceTest.java#L66)  
- tested in the harvester with ` https://bornem-echo.cipalschaubroeck.be/raadpleegomgeving/zittingen/04b3a3a6-9aa6-4e7f-adb5-6ddbf6e71ea6/besluitenlijst `