### PR TITLE
Feature/split files

### DIFF
--- a/config/delta/rules.dev.js
+++ b/config/delta/rules.dev.js
@@ -59,7 +59,28 @@ export default [
       optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
     },
   },
-
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status',
+      },
+      object: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
+    },
+    callback: {
+      method: 'POST',
+      url: 'http://harvest_gen_delta/delta',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
+    },
+  },
 
   {
     match: {

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -137,6 +137,28 @@ export default [
     },
     callback: {
       method: 'POST',
+      url: 'http://harvest_gen_delta/delta',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: ['http://redpencil.data.gift/id/concept/muScope/deltas/initialSync'],
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status',
+      },
+      object: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
+    },
+    callback: {
+      method: 'POST',
       url: 'http://harvest_diff/delta',
     },
     options: {

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -106,8 +106,13 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/compressFiles",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/generatingDelta",
         "nextIndex": "9"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/generatingDelta",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/checking-urls",
+        "nextIndex": "10"
       }
     ]
   },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,10 @@ services:
     restart: "no"
     environment:
       LOGGING_LEVEL: "DEBUG" # optionals
+  harvest_compression:
+    restart: "no"
+  harvest_gen_delta:
+    restart: "no"
 
   harvest_diff:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     logging: *default-logging
 
   harvest_scraper:
-    image: nvdk/lblod-scraper:1.0.0-beta.2
+    image: lblod/scraper:1.0.0-beta.4
     volumes:
       - ./data/files:/share
     environment:
@@ -132,7 +132,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_compression:
-    image: lblod/job-compression-service:0.1.1
+    image: lblod/job-compression-service:0.1.4
     volumes:
       - ./data/files:/share
     environment:
@@ -142,7 +142,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_check-url:
-    image: lblod/harvest-check-url-collection-service:1.2.1
+    image: lblod/harvest-check-url-collection-service:1.3.1
     volumes:
       - ./data/files:/share
     labels:
@@ -197,6 +197,17 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  harvest_gen_delta:
+   image: lblod/harvesting-generation-delta-service:0.0.2
+   environment:
+     TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
+     BUFFER_SIZE: "100"
+   volumes:
+     - ./data/files:/share
+   labels:
+      - "logging=true"
+   restart: always
+   logging: *default-logging
 
   job-controller:
     image: lblod/job-controller-service:1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ x-logging: &default-logging
     max-file: "3"
 
 services:
-
   identifier:
     image: semtech/mu-identifier:1.10.0
     environment:
@@ -132,7 +131,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_compression:
-    image: lblod/job-compression-service:0.1.4
+    image: lblod/job-compression-service:latest
     volumes:
       - ./data/files:/share
     environment:
@@ -150,7 +149,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_import:
-    image: lblod/harvesting-import-service:0.10.0
+    image: lblod/harvesting-import-service:feature-one-file-per-extract
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:
@@ -161,7 +160,7 @@ services:
     logging: *default-logging
 
   harvest_validate:
-    image: lblod/harvesting-validator:0.2.0
+    image: lblod/harvesting-validator:feature-split-files
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
       STRICT_MODE_FILTERING: "false"
@@ -174,7 +173,7 @@ services:
     logging: *default-logging
 
   harvest_diff:
-    image: lblod/harvesting-diff-service:0.1.4
+    image: lblod/harvesting-diff-service:feature-split-files
     environment:
       TARGET_GRAPH: "http://mu.semte.ch/graphs/harvesting"
     volumes:
@@ -185,7 +184,7 @@ services:
     logging: *default-logging
 
   harvest_sameas:
-    image: lblod/import-with-sameas-service:3.6.1
+    image: lblod/import-with-sameas-service:feature-split-files
     environment:
       RENAME_DOMAIN: "http://data.lblod.info/id/"
       TARGET_GRAPH: "http://mu.semte.ch/graphs/public"
@@ -198,19 +197,19 @@ services:
     restart: always
     logging: *default-logging
   harvest_gen_delta:
-   image: lblod/harvesting-generation-delta-service:0.0.8
-   environment:
-     TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
-     BUFFER_SIZE: "100"
-     PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager-besluiten"
-     TARGET_PUBLISHER_GRAPH: "http://redpencil.data.gift/id/deltas/producer/lblod-harvester-besluiten-producer"
+    image: lblod/harvesting-generation-delta-service:feature-split-files
+    environment:
+      TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
+      BUFFER_SIZE: "100"
+      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager-besluiten"
+      TARGET_PUBLISHER_GRAPH: "http://redpencil.data.gift/id/deltas/producer/lblod-harvester-besluiten-producer"
 
-   volumes:
-     - ./data/files:/share
-   labels:
+    volumes:
+      - ./data/files:/share
+    labels:
       - "logging=true"
-   restart: always
-   logging: *default-logging
+    restart: always
+    logging: *default-logging
 
   job-controller:
     image: lblod/job-controller-service:1.0.0
@@ -288,7 +287,7 @@ services:
       SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404,500,503"
       MAX_BODY_SIZE: "50mb"
       PRETTY_PRINT_DIFF_JSON: "true"
-      CONFIG_SERVICES_JSON_PATH: '/config/publication-graph-maintainer/config.json'
+      CONFIG_SERVICES_JSON_PATH: "/config/publication-graph-maintainer/config.json"
     volumes:
       - ./config/delta-producer:/config
       - ./data/files/:/share

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_gen_delta:
-   image: lblod/harvesting-generation-delta-service:0.0.4
+   image: lblod/harvesting-generation-delta-service:0.0.5
    environment:
      TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
      BUFFER_SIZE: "100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,7 @@ services:
     logging: *default-logging
 
   scheduled-job-controller:
-    image: lblod/scheduled-job-controller-service:1.0.1
+    image: lblod/scheduled-job-controller-service:1.0.2
     environment:
       # NOTE: if the delta-events prove to inaccurate,
       # you can go back to previous behavior by commenting out env.var. below

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_gen_delta:
-   image: lblod/harvesting-generation-delta-service:0.0.5
+   image: lblod/harvesting-generation-delta-service:0.0.6
    environment:
      TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
      BUFFER_SIZE: "100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_gen_delta:
-   image: lblod/harvesting-generation-delta-service:0.0.6
+   image: lblod/harvesting-generation-delta-service:0.0.7
    environment:
      TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
      BUFFER_SIZE: "100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     restart: always
     logging: *default-logging
   harvest_gen_delta:
-   image: lblod/harvesting-generation-delta-service:0.0.7
+   image: lblod/harvesting-generation-delta-service:0.0.8
    environment:
      TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
      BUFFER_SIZE: "100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,10 +198,11 @@ services:
     restart: always
     logging: *default-logging
   harvest_gen_delta:
-   image: lblod/harvesting-generation-delta-service:0.0.2
+   image: lblod/harvesting-generation-delta-service:0.0.3
    environment:
      TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
      BUFFER_SIZE: "100"
+     PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager-besluiten"
    volumes:
      - ./data/files:/share
    labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,11 +198,13 @@ services:
     restart: always
     logging: *default-logging
   harvest_gen_delta:
-   image: lblod/harvesting-generation-delta-service:0.0.3
+   image: lblod/harvesting-generation-delta-service:0.0.4
    environment:
      TARGET_DIRECTORY_DELTA_PATH: "/share/deltas/besluiten"
      BUFFER_SIZE: "100"
      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager-besluiten"
+     TARGET_PUBLISHER_GRAPH: "http://redpencil.data.gift/id/deltas/producer/lblod-harvester-besluiten-producer"
+
    volumes:
      - ./data/files:/share
    labels:


### PR DESCRIPTION
I've set it as a draft pull request because it involves a lot of changes everywhere, would be better to let it run for a while on dev before merging / releasing.

After thinking a bit, the diff might not be as accurate, for example if an url link is removed from one of the html pages, we won't be able to add it to the "to-remove.ttl".

On my machine one job takes 25 minutes to finish (4 minutes without the split) -> probably due to more IO?

I started to work on pagination, but after checking the virtuoso.ini file for this project, we set the limit to 1 millions so I stopped (it's only done for the import service, validation  & diff service). If we want it everywhere, please let me know.