### PR TITLE
enable job metrics endpoint for monitoring

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -149,6 +149,13 @@ defmodule Dispatcher do
   end
 
   #################
+  # prometheus reporting
+  #################
+  get "/metrics", %{ layer: :resources, accept: %{ any: true } } do
+    Proxy.forward conn, [], "http://metrics/metrics"
+  end
+
+  #################
   # NOT FOUND
   #################
   match "/*_path", %{ layer: :not_found } do

--- a/config/metrics/index.js
+++ b/config/metrics/index.js
@@ -1,0 +1,2 @@
+import JobMetrics from './job-metrics';
+export default [JobMetrics];

--- a/config/metrics/job-metrics.js
+++ b/config/metrics/job-metrics.js
@@ -1,0 +1,49 @@
+import promClient from 'prom-client';
+import { querySudo as query } from '@lblod/mu-auth-sudo';
+const jobStatusGuage = new promClient.Gauge({
+  name: 'semtech_job_status_count',
+  help: 'jobs per status',
+  labelNames: ['status']
+});
+const register = promClient.register;
+
+const STATUS_MAP = {
+  'http://redpencil.data.gift/id/concept/JobStatus/success': 'success',
+  'http://redpencil.data.gift/id/concept/JobStatus/busy': 'busy',
+  'http://redpencil.data.gift/id/concept/JobStatus/failed': 'failed',
+  'http://redpencil.data.gift/id/concept/JobStatus/scheduled': 'scheduled',
+};
+
+const jobStatusQuery = `
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+SELECT (COUNT(?job) as ?jobs) ?status WHERE {
+       ?job a cogs:Job.
+        OPTIONAL { ?job adms:status ?status . }
+}
+GROUP BY ?status
+ORDER BY ?status
+`;
+
+async function updateJobsPerStatusGauge() {
+  const response = await query(jobStatusQuery);
+  if (response.results.bindings) {
+    for (const binding of response.results.bindings) {
+      const status = STATUS_MAP[binding.status?.value];
+      const count = parseInt(binding.jobs.value);
+      jobStatusGuage.labels({status}).set(count);
+    }
+  }
+}
+
+export default {
+  name: 'job statuses',
+  cronPattern: '*/10 * * * *',
+  async cronExecute() {
+    const data = await updateJobsPerStatusGauge();
+  },
+  async metrics() {
+    return await register.metrics();
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,3 +339,8 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  metrics:
+    image: lblod/metrics-service
+    volumes:
+      - ./data/metrics:/external-metrics
+      - ./config/metrics:/config


### PR DESCRIPTION
can be tested with `curl -H 'Accept: text/plain' http://localhost/metrics`. Should return something like:
```
# HELP semtech_job_status_count jobs per status
# TYPE semtech_job_status_count gauge
semtech_job_status_count{status="busy"} 1
semtech_job_status_count{status="success"} 119
```