### PR TITLE
Add example override file to demonstrate how to connect to another stack

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,9 @@ services:
   dispatcher:
     restart: "no"
 
+  login:
+    restart: "no"
+
   frontend:
     restart: "no"
 
@@ -42,6 +45,9 @@ services:
   harvest_import:
     restart: "no"
 
+  harvest_cleanup:
+    restart: "no"
+
   harvest_validate:
     restart: "no"
     environment:
@@ -62,13 +68,15 @@ services:
 
   scheduled-job-controller:
     restart: "no"
-  login:
+
+  graph-dump-publisher:
     restart: "no"
 
   dbcleanup:
     restart: "no"
 
-  metrics:
-    restart: "no"
   delta-producer-publication-graph-maintainer:
+    restart: "no"
+
+  metrics:
     restart: "no"

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,4 +1,9 @@
-# services:
+services:
+  virtuoso:
+    environment:
+      # Allows for use of a web based UI for queries, such as Yasgui
+      ENABLE_CORS: "true"
+
 #   harvest_scraper:
 #     # Put the scraper on the same network as a local stack so that it can scrape from it
 #     # (needs accompanying network config)

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,13 @@
+# services:
+#   harvest_scraper:
+#     # Put the scraper on the same network as a local stack so that it can scrape from it
+#     # (needs accompanying network config)
+#     networks:
+#       - default
+#       - shared-gn-harvest
+
+# networks:
+#   # Connect to external network to harvest from a local stack e.g. by running publicatie
+#   shared-gn-harvest:
+#     name: shared-gn-harvest
+#     external: true


### PR DESCRIPTION
Using an example override file seems to me to be a more natural way to support developers than for each developer to share their personal collection of overrides on a one-to-one basis. The intent being that a new developer can copy this file when cloning the repo to immediately have some useful overrides, but also to get some example configurations that can be uncommented. If preferred, I could add this example config to the readme instead.