### PR TITLE
cleanup and archive single job

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -120,6 +120,7 @@ export default [
       gracePeriod: 1000,
       ignoreFromSelf: true,
       foldEffectiveChanges: true,
+     sendMatchesOnly: true,
     },
   },
   // {

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -100,6 +100,28 @@ export default [
       sendMatchesOnly: true,
     },
   },
+  {
+    match: {
+      predicate: {
+        type: "uri",
+        value: "http://www.w3.org/ns/adms#status",
+      },
+      object: {
+        type: "uri",
+        value: "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+      },
+    },
+    callback: {
+      method: "POST",
+      url: "http://harvest_cleanup_single_job/delta",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      foldEffectiveChanges: true,
+    },
+  },
   // {
   //   match: {
   //     predicate: {
@@ -232,24 +254,24 @@ export default [
   {
     match: {
       predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
+        type: "uri",
+        value: "http://www.w3.org/ns/adms#status",
       },
       object: {
-        type: 'uri',
-        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
-      }
+        type: "uri",
+        value: "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+      },
     },
     callback: {
-      url: 'http://graph-dump-publisher/delta',
-      method: 'POST'
+      url: "http://graph-dump-publisher/delta",
+      method: "POST",
     },
     options: {
-      resourceFormat: 'v0.0.1',
+      resourceFormat: "v0.0.1",
       gracePeriod: 1000,
       ignoreFromSelf: true,
-      sendMatchesOnly: true
-    }
+      sendMatchesOnly: true,
+    },
   },
   {
     match: {

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -86,7 +86,27 @@
       }
     ]
   },
-  "http://redpencil.data.gift/id/jobs/concept/JobOperation/cleanup": {
+  
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/cleanup-single-job": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/cleanup-single-job",
+        "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/cleanup-single-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/generatingDelta",
+        "nextIndex": "2"
+      }
+    ]
+  },
+   "http://redpencil.data.gift/id/jobs/concept/JobOperation/cleanup": {
     "tasksConfiguration": [
       {
         "currentOperation": null,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,13 +47,12 @@ services:
 
   harvest_cleanup:
     restart: "no"
-
+  harvest_cleanup_single_job:
+    restart: "no"
   harvest_validate:
     restart: "no"
     environment:
       LOGGING_LEVEL: "INFO" # optionals
-  # harvest_compression:
-  #   restart: "no"
   harvest_gen_delta:
     restart: "no"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,14 @@ services:
       - ./data/files:/share
     restart: always
     logging: *default-logging
-
+  harvest_cleanup_single_job:
+   image: lblod/cleanup-single-job-service
+   logging: *default-logging
+   restart: always
+   volumes:
+      - ./data/files:/share
+   links:
+       - database:database
   harvest_validate:
     image: lblod/harvesting-validator:0.4.0
     environment:


### PR DESCRIPTION
Cleanup and archive a single job. The idea of this new job is to have the ability to archive previous jobs from a target url.

The service responsible for the archiving: https://github.com/lblod/cleanup-single-job-service

How it works:

Based on a target url, the service above will fetch all the previous successful jobs, ordered by their modified date desc. 
It also fetches for each job, the result container of the diff step.

Then, we fetch all the `intersect.ttl` and `new-insert.ttl` logical file within the most recent successful job, based on the diff result container. 

For each of these files, we create a new logical file (like a symlink) that is linked to its physical file, but we rename it to `to-remove.ttl`. 

Since the gen delta look at the filename to generate delete delta, it will automatically produces the right delta in the next step. The gen delta should also remove the triples from the publication graph.

Within the same service, we change the status of each previous successful jobs to `archived`.


In order to run the job manually, I've modified the frontend to handle that new status and a new option in the select box of the create new job form. The PR can be found here: https://github.com/lblod/frontend-harvesting-self-service/pull/44

Locally, with a limited set of jobs, it seems working well.  I would like to test it on dev or qa before going to prod.

Please let me know if you have any suggestion or remarks about it. Something to do next is to adjust the local cleanup job to also cleanup the jobs set to archived.

